### PR TITLE
Implement hash-txn helper for multisig transactions

### DIFF
--- a/contracts/multisig.clar
+++ b/contracts/multisig.clar
@@ -135,3 +135,12 @@
     )
 )
 
+;; Issue #3: Hash a stored transaction for signature verification
+(define-read-only (hash-txn (txn-id uint))
+    (let (
+        (txn (unwrap! (map-get? transactions txn-id) ERR_INVALID_TXN_ID))
+        (txn-buff (unwrap! (to-consensus-buff? txn) ERR_INVALID_TXN_ID))
+    )
+        (ok (sha256 txn-buff))
+    )
+)


### PR DESCRIPTION
 - add a read-only hash-txn that hashes stored transaction tuples via to-consensus-buff? and sha256
  - surface ERR_INVALID_TXN_ID when a transaction lookup or serialization fails for predictable error handling
  - prepare groundwork for upcoming signature validation and execution flows